### PR TITLE
Include dynamic scripts in template

### DIFF
--- a/main.py
+++ b/main.py
@@ -77,9 +77,9 @@ HTML_TEMPLATE = """
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
   <script src="/static/js/marked-renderer.js"></script>
-   <script src="/static/js/feedback-integration.js"></script>
-   <script defer src="/static/js/url-decoder.js"></script>
-   <script defer src="/static/js/dynamic-container.js"></script>
+  <script src="/static/js/url-decoder.js"></script>
+  <script src="/static/js/dynamic-container.js"></script>
+  <script src="/static/js/feedback-integration.js"></script>
    <script>
      window.APP_CONFIG = { sasToken: "{{ sas_token }}" };
      console.log("Injected SAS_TOKEN:", window.APP_CONFIG.sasToken);

--- a/rag_assistant_v2.py
+++ b/rag_assistant_v2.py
@@ -1794,3 +1794,6 @@ if __name__ == "__main__":
         print("\nAll tests passed!")
     else:
         print("\nSome tests failed. Check the logs for details.")
+
+# Backwards compatibility alias
+FlaskRAGAssistant = FlaskRAGAssistantWithHistory


### PR DESCRIPTION
## Summary
- load URL decoder and dynamic container helpers in main template
- provide alias `FlaskRAGAssistant` for backwards compatibility

## Testing
- `pytest -q` *(fails: missing Azure OpenAI credentials)*

------
https://chatgpt.com/codex/tasks/task_e_688bf1ce74e483288a3a52b3e75265d4